### PR TITLE
fix a syntax error which could cause installing failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,4 +19,4 @@ exclude = '''
   | foo.py           # also separately exclude a file named foo.py in
                      # the root of the project
 )
-
+'''


### PR DESCRIPTION
` ''' `  symbol missing at the end of 'pyproject.toml'.

That could make installing failed